### PR TITLE
Add agent blueprints for AI-first startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,15 @@ Subscriptions are becoming less relevant for AI-native businesses.
 - **Solo unicorns:** Likely **2026–2028**
 
 Never before could one person build something worth $1B — until now.
+
+---
+
+## 10. Agent Blueprints
+Detailed guides for building the specialized agents that run your company:
+- [Engineering Agent](agents/engineering.md)
+- [Design Agent](agents/design.md)
+- [Marketing Agent](agents/marketing.md)
+- [Sales Agent](agents/sales.md)
+- [Support Agent](agents/support.md)
+
+Start by deploying a single agent on a narrow task, capture feedback, and expand automation over time.

--- a/agents/design.md
+++ b/agents/design.md
@@ -1,0 +1,24 @@
+# Design Agent
+
+## Mission
+Create cohesive user experiences and brand assets that amplify the founder's vision.
+
+## Core Tasks
+- Produce UI/UX mockups and iterate with feedback
+- Generate logos, icons, and marketing assets
+- Maintain design system and accessibility standards
+
+## Tools & Integrations
+- Figma or Penpot for wireframes
+- DALL·E or Midjourney for imagery
+- Accessibility checkers (axe, Lighthouse)
+
+## Sample Prompt
+```
+You are the Design Agent. Draft a responsive landing page layout for product Z. Provide color palette, typography, and asset suggestions.
+```
+
+## Success Metrics
+- User satisfaction scores
+- Brand consistency
+- Accessibility compliance

--- a/agents/engineering.md
+++ b/agents/engineering.md
@@ -1,0 +1,26 @@
+# Engineering Agent
+
+## Mission
+Build and maintain product features, tests, and infrastructure at startup speed.
+
+## Core Tasks
+- Generate and refactor code
+- Write and run unit/integration tests
+- Manage deployments and CI/CD pipelines
+- Monitor performance and security
+
+## Tools & Integrations
+- GitHub for version control
+- CI services (GitHub Actions, CircleCI)
+- Containerization via Docker
+- Observability: Sentry, Datadog
+
+## Sample Prompt
+```
+You are the Engineering Agent. Implement feature X using language Y. Include unit tests and update documentation. Ensure code passes `npm test` and `eslint`.
+```
+
+## Success Metrics
+- Test pass rate
+- Deployment frequency
+- Mean time to recovery

--- a/agents/marketing.md
+++ b/agents/marketing.md
@@ -1,0 +1,24 @@
+# Marketing Agent
+
+## Mission
+Grow the audience through compelling content and data-driven distribution.
+
+## Core Tasks
+- Write blog posts, newsletters, and social updates
+- Perform SEO research and keyword optimization
+- Analyze campaign analytics and iterate
+
+## Tools & Integrations
+- Scheduling via Buffer or Hootsuite
+- SEO tools like Ahrefs or Semrush
+- Analytics: Google Analytics, OpenAI analytics
+
+## Sample Prompt
+```
+You are the Marketing Agent. Draft a Twitter thread announcing feature Q. Include hashtags, call to action, and schedule for peak engagement.
+```
+
+## Success Metrics
+- Follower/subscriber growth
+- Engagement rate
+- Conversion rate from campaigns

--- a/agents/sales.md
+++ b/agents/sales.md
@@ -1,0 +1,24 @@
+# Sales Agent
+
+## Mission
+Convert interested leads into paying customers with personalized, persistent outreach.
+
+## Core Tasks
+- Qualify inbound leads and enrich contact data
+- Run outbound email or DM sequences
+- Track pipeline and handoff hot leads to founder
+
+## Tools & Integrations
+- CRM (HubSpot, Pipedrive)
+- Email automation (Apollo, Mailshake)
+- Enrichment via Clearbit or LinkedIn API
+
+## Sample Prompt
+```
+You are the Sales Agent. Generate a 3-step email sequence for prospect Y at company Z highlighting value proposition V.
+```
+
+## Success Metrics
+- Response and demo booking rate
+- Sales cycle length
+- Monthly recurring revenue added

--- a/agents/support.md
+++ b/agents/support.md
@@ -1,0 +1,24 @@
+# Support Agent
+
+## Mission
+Provide instant, accurate help to users while turning feedback into product insights.
+
+## Core Tasks
+- Resolve support tickets and live chat inquiries
+- Maintain knowledge base and auto-generate FAQs
+- Escalate bugs or feature requests to engineering
+
+## Tools & Integrations
+- Help desk (Zendesk, Intercom)
+- Documentation via Notion or GitBook
+- Sentiment analysis to track user happiness
+
+## Sample Prompt
+```
+You are the Support Agent. Answer the following customer question using the knowledge base: "How do I reset my password?" If unsure, ask for clarification.
+```
+
+## Success Metrics
+- First response time
+- Customer satisfaction scores
+- Number of issues resolved without human intervention


### PR DESCRIPTION
## Summary
- Document detailed roles for engineering, design, marketing, sales and support agents
- Link to agent guides from README for quick reference

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898184d041883228483bee4cefe4ece