### PR TITLE
Add basic agent classes and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,15 @@
+"""Agent classes implementing core tasks for a solo AI-first company."""
+
+from .engineering import EngineeringAgent
+from .design import DesignAgent
+from .marketing import MarketingAgent
+from .sales import SalesAgent
+from .support import SupportAgent
+
+__all__ = [
+    "EngineeringAgent",
+    "DesignAgent",
+    "MarketingAgent",
+    "SalesAgent",
+    "SupportAgent",
+]

--- a/agents/design.py
+++ b/agents/design.py
@@ -1,0 +1,24 @@
+"""Design agent to produce mockups and assets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class DesignAgent:
+    """Automates design-related tasks."""
+
+    name: str = "Design Agent"
+
+    def create_mockup(self, product: str) -> str:
+        """Simulate creating a UI/UX mockup."""
+        return f"Created mockup for {product}."
+
+    def generate_logo(self, brand: str) -> str:
+        """Simulate generating a logo."""
+        return f"Generated logo for {brand}."
+
+    def check_accessibility(self, component: str) -> str:
+        """Simulate running an accessibility check."""
+        return f"Checked accessibility for {component}."

--- a/agents/engineering.py
+++ b/agents/engineering.py
@@ -1,0 +1,28 @@
+"""Engineering agent with methods for core engineering tasks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EngineeringAgent:
+    """Automates software engineering tasks."""
+
+    name: str = "Engineering Agent"
+
+    def generate_code(self, feature: str, language: str) -> str:
+        """Simulate code generation for a feature."""
+        return f"Generated {language} code for {feature}."
+
+    def write_tests(self, module: str) -> str:
+        """Simulate writing tests for a module."""
+        return f"Wrote tests for {module}."
+
+    def deploy(self, environment: str) -> str:
+        """Simulate deployment to an environment."""
+        return f"Deployed to {environment}."
+
+    def monitor(self, service: str) -> str:
+        """Simulate monitoring a service."""
+        return f"Monitoring {service}."

--- a/agents/marketing.py
+++ b/agents/marketing.py
@@ -1,0 +1,24 @@
+"""Marketing agent to generate content and analyze campaigns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MarketingAgent:
+    """Automates marketing tasks."""
+
+    name: str = "Marketing Agent"
+
+    def write_content(self, topic: str) -> str:
+        """Simulate writing a piece of content."""
+        return f"Wrote content about {topic}."
+
+    def perform_seo_research(self, keyword: str) -> str:
+        """Simulate SEO research."""
+        return f"Researched SEO for {keyword}."
+
+    def analyze_campaign(self, campaign: str) -> str:
+        """Simulate campaign analytics."""
+        return f"Analyzed campaign {campaign}."

--- a/agents/sales.py
+++ b/agents/sales.py
@@ -1,0 +1,24 @@
+"""Sales agent for qualifying leads and running outreach."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SalesAgent:
+    """Automates sales tasks."""
+
+    name: str = "Sales Agent"
+
+    def qualify_lead(self, lead: str) -> str:
+        """Simulate lead qualification."""
+        return f"Qualified lead {lead}."
+
+    def run_sequence(self, prospect: str) -> str:
+        """Simulate running an email sequence."""
+        return f"Ran outreach sequence for {prospect}."
+
+    def track_pipeline(self, deal: str) -> str:
+        """Simulate tracking a deal in the pipeline."""
+        return f"Tracked deal {deal}."

--- a/agents/support.py
+++ b/agents/support.py
@@ -1,0 +1,24 @@
+"""Support agent for resolving customer issues."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SupportAgent:
+    """Automates support tasks."""
+
+    name: str = "Support Agent"
+
+    def resolve_ticket(self, ticket_id: int) -> str:
+        """Simulate resolving a support ticket."""
+        return f"Resolved ticket {ticket_id}."
+
+    def update_knowledge_base(self, topic: str) -> str:
+        """Simulate updating the knowledge base."""
+        return f"Updated knowledge base with {topic}."
+
+    def escalate(self, issue: str) -> str:
+        """Simulate escalating an issue to engineering."""
+        return f"Escalated issue {issue} to engineering."

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,43 @@
+from agents import (
+    EngineeringAgent,
+    DesignAgent,
+    MarketingAgent,
+    SalesAgent,
+    SupportAgent,
+)
+
+
+def test_engineering_agent():
+    agent = EngineeringAgent()
+    assert agent.generate_code("feature X", "Python") == "Generated Python code for feature X."
+    assert agent.write_tests("module Y") == "Wrote tests for module Y."
+    assert agent.deploy("staging") == "Deployed to staging."
+    assert agent.monitor("service Z") == "Monitoring service Z."
+
+
+def test_design_agent():
+    agent = DesignAgent()
+    assert agent.create_mockup("product Z") == "Created mockup for product Z."
+    assert agent.generate_logo("brand A") == "Generated logo for brand A."
+    assert agent.check_accessibility("component B") == "Checked accessibility for component B."
+
+
+def test_marketing_agent():
+    agent = MarketingAgent()
+    assert agent.write_content("feature Q") == "Wrote content about feature Q."
+    assert agent.perform_seo_research("keyword K") == "Researched SEO for keyword K."
+    assert agent.analyze_campaign("campaign C") == "Analyzed campaign campaign C."
+
+
+def test_sales_agent():
+    agent = SalesAgent()
+    assert agent.qualify_lead("lead L") == "Qualified lead lead L."
+    assert agent.run_sequence("prospect P") == "Ran outreach sequence for prospect P."
+    assert agent.track_pipeline("deal D") == "Tracked deal deal D."
+
+
+def test_support_agent():
+    agent = SupportAgent()
+    assert agent.resolve_ticket(42) == "Resolved ticket 42."
+    assert agent.update_knowledge_base("topic T") == "Updated knowledge base with topic T."
+    assert agent.escalate("issue I") == "Escalated issue issue I to engineering."


### PR DESCRIPTION
## Summary
- add dataclass-based Engineering, Design, Marketing, Sales, and Support agents with simple task methods
- provide unit tests covering each agent's core behaviours
- include gitignore for Python caches

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68981b80dc3c8322bdedde1e72317fe5