### PR TITLE
Add basic Python implementations for company agents

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,13 @@
+from .engineering_agent import EngineeringAgent
+from .design_agent import DesignAgent
+from .marketing_agent import MarketingAgent
+from .sales_agent import SalesAgent
+from .support_agent import SupportAgent
+
+__all__ = [
+    "EngineeringAgent",
+    "DesignAgent",
+    "MarketingAgent",
+    "SalesAgent",
+    "SupportAgent",
+]

--- a/agents/design_agent.py
+++ b/agents/design_agent.py
@@ -1,0 +1,17 @@
+from typing import Dict, List
+
+
+class DesignAgent:
+    """Design Agent handles UI/UX and asset generation tasks."""
+
+    def produce_mockups(self, components: List[str]) -> Dict[str, str]:
+        """Return simple mockup representation for each component."""
+        return {component: f"mockup for {component}" for component in components}
+
+    def generate_assets(self, assets: List[str]) -> List[str]:
+        """Return asset file names for provided asset types."""
+        return [f"{asset}.png" for asset in assets]
+
+    def maintain_design_system(self, guidelines: Dict[str, str]) -> Dict[str, str]:
+        """Return guidelines to simulate maintaining design system."""
+        return guidelines

--- a/agents/engineering_agent.py
+++ b/agents/engineering_agent.py
@@ -1,0 +1,27 @@
+from typing import Callable, Dict, List
+
+
+class EngineeringAgent:
+    """Engineering Agent implements core engineering tasks."""
+
+    def generate_and_refactor_code(self, code: str) -> str:
+        """Return code stripped of trailing whitespace to simulate refactoring."""
+        return "\n".join(line.rstrip() for line in code.splitlines())
+
+    def write_and_run_tests(self, tests: List[Callable[[], bool]]) -> bool:
+        """
+        Execute each test callable and return True if all pass.
+
+        A failing test raises an AssertionError.
+        """
+        for test in tests:
+            assert test()
+        return True
+
+    def manage_deployments_and_ci_cd(self, steps: List[str]) -> List[str]:
+        """Simulate deployment pipeline by marking each step as executed."""
+        return [f"{step} executed" for step in steps]
+
+    def monitor_performance_and_security(self, metrics: Dict[str, float]) -> Dict[str, float]:
+        """Return provided metrics to simulate monitoring."""
+        return metrics

--- a/agents/marketing_agent.py
+++ b/agents/marketing_agent.py
@@ -1,0 +1,18 @@
+from typing import Dict, List
+
+
+class MarketingAgent:
+    """Marketing Agent creates content and analyzes campaigns."""
+
+    def write_blog_post(self, topic: str) -> str:
+        """Return a simple blog post draft for a given topic."""
+        return f"Blog post about {topic}"
+
+    def perform_seo_research(self, keyword: str) -> List[str]:
+        """Return a list of related keywords to simulate SEO research."""
+        return [keyword, f"{keyword} tips", f"{keyword} tutorial"]
+
+    def analyze_campaign(self, views: int, clicks: int) -> Dict[str, float]:
+        """Return campaign metrics including click-through rate (CTR)."""
+        ctr = (clicks / views) if views else 0
+        return {"views": views, "clicks": clicks, "ctr": ctr}

--- a/agents/sales_agent.py
+++ b/agents/sales_agent.py
@@ -1,0 +1,21 @@
+from typing import Dict, List
+
+
+class SalesAgent:
+    """Sales Agent converts leads into customers."""
+
+    def qualify_lead(self, lead_info: Dict[str, int]) -> bool:
+        """Return True if lead has budget and interest."""
+        return bool(lead_info.get("budget")) and bool(lead_info.get("interest"))
+
+    def run_outbound_sequence(self, prospect: str) -> List[str]:
+        """Return a simple three-step outreach sequence for prospect."""
+        return [
+            f"Introductory email to {prospect}",
+            f"Follow-up email to {prospect}",
+            f"Closing email to {prospect}",
+        ]
+
+    def track_pipeline(self, leads: List[str]) -> List[str]:
+        """Return the list of leads to simulate tracking pipeline."""
+        return leads

--- a/agents/support_agent.py
+++ b/agents/support_agent.py
@@ -1,0 +1,22 @@
+from typing import Dict
+
+
+class SupportAgent:
+    """Support Agent resolves tickets and maintains a knowledge base."""
+
+    def __init__(self) -> None:
+        self.knowledge_base: Dict[str, str] = {
+            "How do I reset my password?": "Click 'Forgot password' on the login page and follow the instructions."
+        }
+
+    def resolve_ticket(self, question: str) -> str:
+        """Answer a support question using the knowledge base."""
+        return self.knowledge_base.get(question, "Please provide more details.")
+
+    def update_knowledge_base(self, question: str, answer: str) -> None:
+        """Update the knowledge base with a new Q&A pair."""
+        self.knowledge_base[question] = answer
+
+    def escalate_issue(self, issue: str) -> str:
+        """Return a message indicating the issue has been escalated."""
+        return f"Escalated: {issue}"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,55 @@
+from agents import (
+    EngineeringAgent,
+    DesignAgent,
+    MarketingAgent,
+    SalesAgent,
+    SupportAgent,
+)
+
+
+def test_engineering_agent():
+    agent = EngineeringAgent()
+    assert agent.generate_and_refactor_code("print('hi')  ") == "print('hi')"
+    assert agent.write_and_run_tests([lambda: 1 + 1 == 2]) is True
+    assert agent.manage_deployments_and_ci_cd(["build", "deploy"]) == [
+        "build executed",
+        "deploy executed",
+    ]
+    metrics = {"performance": 0.9, "security": 1.0}
+    assert agent.monitor_performance_and_security(metrics) == metrics
+
+
+def test_design_agent():
+    agent = DesignAgent()
+    mockups = agent.produce_mockups(["button"])
+    assert mockups["button"] == "mockup for button"
+    assert agent.generate_assets(["logo"]) == ["logo.png"]
+    guidelines = {"color": "#fff"}
+    assert agent.maintain_design_system(guidelines) is guidelines
+
+
+def test_marketing_agent():
+    agent = MarketingAgent()
+    assert agent.write_blog_post("feature X") == "Blog post about feature X"
+    keywords = agent.perform_seo_research("test")
+    assert "test tips" in keywords
+    metrics = agent.analyze_campaign(100, 25)
+    assert metrics["ctr"] == 0.25
+
+
+def test_sales_agent():
+    agent = SalesAgent()
+    lead = {"budget": 1000, "interest": True}
+    assert agent.qualify_lead(lead) is True
+    sequence = agent.run_outbound_sequence("Alice")
+    assert sequence[0].startswith("Introductory")
+    pipeline = agent.track_pipeline(["Lead1"])
+    assert pipeline == ["Lead1"]
+
+
+def test_support_agent():
+    agent = SupportAgent()
+    assert "Forgot password" in agent.resolve_ticket("How do I reset my password?")
+    agent.update_knowledge_base("New question", "New answer")
+    assert agent.resolve_ticket("New question") == "New answer"
+    assert agent.escalate_issue("bug") == "Escalated: bug"


### PR DESCRIPTION
## Summary
- implement EngineeringAgent with simple code refactoring, testing, deployment, and monitoring helpers
- add DesignAgent, MarketingAgent, SalesAgent, and SupportAgent classes for other business functions
- cover new agents with basic unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981b80dc3c8322bdedde1e72317fe5