### PR TITLE
Add basic agent task implementations

### DIFF
--- a/agent_tasks/__init__.py
+++ b/agent_tasks/__init__.py
@@ -1,0 +1,13 @@
+from .design import DesignAgent
+from .engineering import EngineeringAgent
+from .marketing import MarketingAgent
+from .sales import SalesAgent
+from .support import SupportAgent
+
+__all__ = [
+    "DesignAgent",
+    "EngineeringAgent",
+    "MarketingAgent",
+    "SalesAgent",
+    "SupportAgent",
+]

--- a/agent_tasks/design.py
+++ b/agent_tasks/design.py
@@ -1,0 +1,14 @@
+class DesignAgent:
+    """Creates cohesive user experiences and brand assets."""
+
+    def produce_mockups(self) -> str:
+        """Produce UI/UX mockups and iterate with feedback."""
+        return "Producing UI/UX mockups and iterating with feedback."
+
+    def generate_assets(self) -> str:
+        """Generate logos, icons, and marketing assets."""
+        return "Generating logos, icons, and marketing assets."
+
+    def maintain_design_system(self) -> str:
+        """Maintain design system and accessibility standards."""
+        return "Maintaining design system and accessibility standards."

--- a/agent_tasks/engineering.py
+++ b/agent_tasks/engineering.py
@@ -1,0 +1,18 @@
+class EngineeringAgent:
+    """Builds and maintains product features, tests, and infrastructure."""
+
+    def generate_code(self) -> str:
+        """Generate and refactor code."""
+        return "Generating and refactoring code."
+
+    def run_tests(self) -> str:
+        """Write and run unit/integration tests."""
+        return "Writing and running unit/integration tests."
+
+    def manage_deployments(self) -> str:
+        """Manage deployments and CI/CD pipelines."""
+        return "Managing deployments and CI/CD pipelines."
+
+    def monitor_systems(self) -> str:
+        """Monitor performance and security."""
+        return "Monitoring performance and security."

--- a/agent_tasks/marketing.py
+++ b/agent_tasks/marketing.py
@@ -1,0 +1,14 @@
+class MarketingAgent:
+    """Grows the audience through compelling content and data-driven distribution."""
+
+    def write_content(self) -> str:
+        """Write blog posts, newsletters, and social updates."""
+        return "Writing blog posts, newsletters, and social updates."
+
+    def perform_seo_research(self) -> str:
+        """Perform SEO research and keyword optimization."""
+        return "Performing SEO research and keyword optimization."
+
+    def analyze_campaigns(self) -> str:
+        """Analyze campaign analytics and iterate."""
+        return "Analyzing campaign analytics and iterating."

--- a/agent_tasks/sales.py
+++ b/agent_tasks/sales.py
@@ -1,0 +1,14 @@
+class SalesAgent:
+    """Converts interested leads into paying customers."""
+
+    def qualify_leads(self) -> str:
+        """Qualify inbound leads and enrich contact data."""
+        return "Qualifying inbound leads and enriching contact data."
+
+    def run_outbound_sequences(self) -> str:
+        """Run outbound email or DM sequences."""
+        return "Running outbound email or DM sequences."
+
+    def track_pipeline(self) -> str:
+        """Track pipeline and handoff hot leads to founder."""
+        return "Tracking pipeline and handing off hot leads to founder."

--- a/agent_tasks/support.py
+++ b/agent_tasks/support.py
@@ -1,0 +1,14 @@
+class SupportAgent:
+    """Provides instant, accurate help to users and gathers product insights."""
+
+    def resolve_tickets(self) -> str:
+        """Resolve support tickets and live chat inquiries."""
+        return "Resolving support tickets and live chat inquiries."
+
+    def maintain_knowledge_base(self) -> str:
+        """Maintain knowledge base and auto-generate FAQs."""
+        return "Maintaining knowledge base and auto-generating FAQs."
+
+    def escalate_issues(self) -> str:
+        """Escalate bugs or feature requests to engineering."""
+        return "Escalating bugs or feature requests to engineering."


### PR DESCRIPTION
## Summary
- add simple Python implementations for Design, Engineering, Marketing, Sales, and Support agents
- expose agent classes through `agent_tasks` package

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981b80dc3c8322bdedde1e72317fe5